### PR TITLE
Added 13 digit id clause to playlist regexp

### DIFF
--- a/src/classes/modules/YouTubePlaylist.ts
+++ b/src/classes/modules/YouTubePlaylist.ts
@@ -29,7 +29,7 @@ export class YouTubePlaylist extends YouTubeBase {
 	 * @param id The video ID.
 	 */
 	private static validateId(id: string) {
-		const regex = /^[a-zA-Z0-9-_]{34}$/;
+		const regex = /^([a-zA-Z0-9-_]{34}|[a-zA-Z0-9-_]{13})$/;
 		return regex.test(id);
 	}
 


### PR DESCRIPTION
Did not see any template for contributions, so I'm just going to open a pr. Let me know if changes are needed!


## Problem

Youtube mix playlists are not supported due to the ID validation regexp validating 34 characters.

## Solution

Confirmed that youtube mix playlists IDs have a length of 13 and adjusted the regexp to evaluate for 34 or 13.


Hope this is helpful :)